### PR TITLE
Log queue name on consumer timed out channel error

### DIFF
--- a/deps/rabbit/src/rabbit_channel.erl
+++ b/deps/rabbit/src/rabbit_channel.erl
@@ -2771,10 +2771,10 @@ handle_consumer_timed_out(Timeout,#pending_ack{delivery_tag = DeliveryTag, tag =
                   rabbit_misc:rs(QName),
                   DeliveryTag, Timeout]),
     Ex = rabbit_misc:amqp_error(precondition_failed,
-				"delivery acknowledgement on channel ~w timed out. "
+				"delivery acknowledgement on channel ~w and queue ~ts timed out. "
 				"Timeout value used: ~tp ms. "
 				"This timeout value can be configured, see consumers doc guide to learn more",
-				[Channel, Timeout], none),
+				[Channel, rabbit_misc:rs(QName), Timeout], none),
     handle_exception(Ex, State).
 
 handle_queue_actions(Actions, State) ->


### PR DESCRIPTION
## Proposed Changes

Adds the queue name to the channel error log when a consumer times out.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code._

- [x] **Mandatory**: I (or my employer/client) have have signed the CA (see https://github.com/rabbitmq/cla)
- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments


